### PR TITLE
add commas to coordinates in search command

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -31,7 +31,7 @@ import {decrypt} from './encryption.js';
  */
 function parseCoordinates(client, parameters, errorClient) {
     const coordinates = Object.fromEntries(parameters
-        .map(coordinate => coordinate.replaceAll(',', ''))
+        .map(coordinate => coordinate.replace(new RegExp(","), ''))
         .map((coordinate, index) => coordinate.startsWith('~')
             ? (parseFloat(coordinate.slice(1)) || 0) + client.__state.position[COORDINATE_KEYS[index]]
             : coordinate)

--- a/src/commands.js
+++ b/src/commands.js
@@ -31,7 +31,7 @@ import {decrypt} from './encryption.js';
  */
 function parseCoordinates(client, parameters, errorClient) {
     const coordinates = Object.fromEntries(parameters
-        .map((coordinate) => coordinate.replaceAll(',', ''))
+        .map(coordinate => coordinate.replaceAll(',', ''))
         .map((coordinate, index) => coordinate.startsWith('~')
             ? (parseFloat(coordinate.slice(1)) || 0) + client.__state.position[COORDINATE_KEYS[index]]
             : coordinate)
@@ -153,7 +153,7 @@ export const commands = {
         const {x, y, z, shelf, shulker, book, page} = fromPageId(fromPage(decrypt(searchQuery)));
         const [shelfX, shelfY, shelfZ] = BOOKSHELF_COORDINATES[shelf].split(' ').map(coordinate => parseInt(coordinate));
         const tpCoordinates = Object.values(BOOKSHELF_COORDINATES_MAP)[shelf];
-        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ].map(coordinate => coordinate.toLocaleString("en-US"));
+        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ].map(coordinate => coordinate.toLocaleString('en-US'));
         packets.chat(client, [
             ...emojiFormat(
                 '🟪➕=== Search Results ===\n' +

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,6 +2,7 @@ import {
     clearHighlightInterval,
     createHighlightInterval,
     error,
+    formatCoordinate,
     fromPage,
     fromPageId,
     getChunk,
@@ -152,10 +153,11 @@ export const commands = {
         const {x, y, z, shelf, shulker, book, page} = fromPageId(fromPage(decrypt(searchQuery)));
         const [shelfX, shelfY, shelfZ] = BOOKSHELF_COORDINATES[shelf].split(' ').map(coordinate => parseInt(coordinate));
         const tpCoordinates = Object.values(BOOKSHELF_COORDINATES_MAP)[shelf];
+        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ].map(formatCoordinate);
         packets.chat(client, [
             ...emojiFormat(
                 '🟪➕=== Search Results ===\n' +
-                `⬜➖That text was found at 🟥➕x=${x + shelfX} y=${y + shelfY} z=${z + shelfZ}⬜➖.\n` +
+                `⬜➖That text was found at 🟥➕x=${formattedX} y=${formattedY} z=${formattedZ}⬜➖.\n` +
                 `In 🟨➕shelf ${shelf + 1n}⬜➖, 🟩➕shulker ${shulker + 1n}⬜➖, 🟦➕book ${book + 1n}⬜➖, 🟪➕page ${page + 1n}⬜➖.\n\n` +
                 `Actions: 🟦`,
             ),

--- a/src/commands.js
+++ b/src/commands.js
@@ -31,7 +31,7 @@ import {decrypt} from './encryption.js';
  */
 function parseCoordinates(client, parameters, errorClient) {
     const coordinates = Object.fromEntries(parameters
-        .map(coordinate => coordinate.replace(new RegExp(","), ''))
+        .map(coordinate => coordinate.replace(new RegExp(','), ''))
         .map((coordinate, index) => coordinate.startsWith('~')
             ? (parseFloat(coordinate.slice(1)) || 0) + client.__state.position[COORDINATE_KEYS[index]]
             : coordinate)

--- a/src/commands.js
+++ b/src/commands.js
@@ -153,7 +153,8 @@ export const commands = {
         const {x, y, z, shelf, shulker, book, page} = fromPageId(fromPage(decrypt(searchQuery)));
         const [shelfX, shelfY, shelfZ] = BOOKSHELF_COORDINATES[shelf].split(' ').map(coordinate => parseInt(coordinate));
         const tpCoordinates = Object.values(BOOKSHELF_COORDINATES_MAP)[shelf];
-        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ].map(coordinate => coordinate.toLocaleString('en-US'));
+        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ]
+            .map(coordinate => Math.abs(coordinate) > 999999 ? coordinate.toLocaleString('en-US') : coordinate);
         packets.chat(client, [
             ...emojiFormat(
                 '🟪➕=== Search Results ===\n' +

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,7 +2,6 @@ import {
     clearHighlightInterval,
     createHighlightInterval,
     error,
-    formatCoordinate,
     fromPage,
     fromPageId,
     getChunk,
@@ -32,6 +31,7 @@ import {decrypt} from './encryption.js';
  */
 function parseCoordinates(client, parameters, errorClient) {
     const coordinates = Object.fromEntries(parameters
+        .map((coordinate) => coordinate.replaceAll(',', ''))
         .map((coordinate, index) => coordinate.startsWith('~')
             ? (parseFloat(coordinate.slice(1)) || 0) + client.__state.position[COORDINATE_KEYS[index]]
             : coordinate)
@@ -153,7 +153,7 @@ export const commands = {
         const {x, y, z, shelf, shulker, book, page} = fromPageId(fromPage(decrypt(searchQuery)));
         const [shelfX, shelfY, shelfZ] = BOOKSHELF_COORDINATES[shelf].split(' ').map(coordinate => parseInt(coordinate));
         const tpCoordinates = Object.values(BOOKSHELF_COORDINATES_MAP)[shelf];
-        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ].map(formatCoordinate);
+        const [formattedX, formattedY, formattedZ] = [x + shelfX, y + shelfY, z + shelfZ].map(coordinate => coordinate.toLocaleString("en-US"));
         packets.chat(client, [
             ...emojiFormat(
                 '🟪➕=== Search Results ===\n' +

--- a/src/helper.js
+++ b/src/helper.js
@@ -308,3 +308,10 @@ export function notice(client, message) {
 export function error(client, message) {
     packets.chat(client, emojiFormat(`🟥➕[ERROR]➖ ${message}`));
 }
+
+/**
+ * Simple function that formats a coordinate to be more human readable.
+ */
+ export function formatCoordinate(coordinate) {
+    return coordinate.toLocaleString("en-US");
+}

--- a/src/helper.js
+++ b/src/helper.js
@@ -308,10 +308,3 @@ export function notice(client, message) {
 export function error(client, message) {
     packets.chat(client, emojiFormat(`🟥➕[ERROR]➖ ${message}`));
 }
-
-/**
- * Simple function that formats a coordinate to be more human readable.
- */
- export function formatCoordinate(coordinate) {
-    return coordinate.toLocaleString("en-US");
-}


### PR DESCRIPTION
Adding human readable strings for the search command.

When the coordinates for the search command get big (> 1,000,000, especially > 10,000,000) it becomes really hard to type out coordinates without any commas existing.

Technically it won't really do much for the Y coordinate but might as well apply it to that as well to be consistent.